### PR TITLE
Add an import to fix implicit declaration error during make

### DIFF
--- a/sys/dev/netmap/netmap_mem2.c
+++ b/sys/dev/netmap/netmap_mem2.c
@@ -52,6 +52,7 @@ __FBSDID("$FreeBSD: head/sys/dev/netmap/netmap.c 241723 2012-10-19 09:41:45Z gle
 
 #include <net/netmap.h>
 #include <dev/netmap/netmap_kern.h>
+#include <linux/vmalloc.h>
 #include "netmap_mem2.h"
 
 #define NETMAP_BUF_MAX_NUM	20*4096*2	/* large machine */


### PR DESCRIPTION
Added an import that fixes implicit declaration errors that prevents make from compiling netmap. Fixes issue #45 on the Google Code repository.

https://code.google.com/p/netmap/issues/detail?id=45