### PR TITLE
Remove redundant field assignment

### DIFF
--- a/examples/pkt-gen.c
+++ b/examples/pkt-gen.c
@@ -625,7 +625,6 @@ initialize_packet(struct targ *targ)
         ip->ip_id = 0;
         ip->ip_tos = IPTOS_LOWDELAY;
 	ip->ip_len = ntohs(targ->g->pkt_size - sizeof(*eh));
-        ip->ip_id = 0;
         ip->ip_off = htons(IP_DF); /* Don't fragment */
         ip->ip_ttl = IPDEFTTL;
 	ip->ip_p = IPPROTO_UDP;


### PR DESCRIPTION
Removed a redundant assignment to a field while initializing packets.